### PR TITLE
Fix side effects caused by Content-Security-Policy-Report-Only header

### DIFF
--- a/src/Report_Types.php
+++ b/src/Report_Types.php
@@ -41,7 +41,13 @@ class Report_Types {
 			'csp'                      => array(
 				'title'           => __( 'Content Security Policy', 'reporting-api' ),
 				'header_callback' => function( $group ) {
-					$value = "default-src https:; report-to {$group}";
+					// Use report-uri directive for browser backward compatibility.
+					$report_uri = '';
+					if ( 'default' === $group ) {
+						$report_uri = 'report-uri ' . Plugin::instance()->reporting_endpoint_url() . '; ';
+					}
+
+					$value = "{$report_uri}report-to {$group}";
 					header( "Content-Security-Policy-Report-Only: {$value}" );
 				},
 			),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Ensure the usage of `Content-Security-Policy-Report-Only` header does not cause side effects.

<!-- Please reference the issue this PR addresses. -->
Adresses issue #5 

## Relevant technical choices
Unfortunately, [not all browsers support the `Content-Security-Policy-Report-Only` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only#Browser_compatibility), and for some reason enforce the policy directives included in that header, rather than actually using them for reporting only. Therefore the extra directive has been removed.

In addition to that, for the `default` group, the URI is provided directly via [`report-uri`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri) as a fallback, since [`report-to`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to) is mostly unsupported today.

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
