### PR TITLE
Prime report log data caches to improve performance for report queries

### DIFF
--- a/src/Report_Query.php
+++ b/src/Report_Query.php
@@ -645,14 +645,16 @@ class Report_Query {
 			return;
 		}
 
+		$ids_sql_list = implode( ',', array_fill( 0, count( $non_cached_ids ), '%d' ) );
+
 		$table_name = Plugin::instance()->report_logs()->get_db_table_name();
 
 		// Request regular columns for each report.
 		$fresh_results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			sprintf(
-				// phpcs:ignore WordPress.DB.PreparedSQL
-				"SELECT report_id, COUNT(*) AS count, MIN(triggered) AS first_triggered, MAX(triggered) AS last_triggered, MIN(reported) AS first_reported, MAX(reported) AS last_reported FROM {$table_name} WHERE report_id IN (%s) GROUP BY report_id",
-				join( ',', array_map( 'intval', $non_cached_ids ) ) // phpcs:ignore WordPress.DB.PreparedSQL
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				"SELECT report_id, COUNT(*) AS count, MIN(triggered) AS first_triggered, MAX(triggered) AS last_triggered, MIN(reported) AS first_reported, MAX(reported) AS last_reported FROM {$table_name} WHERE report_id IN ({$ids_sql_list}) GROUP BY report_id",
+				$non_cached_ids
 			),
 			ARRAY_A
 		);
@@ -662,20 +664,20 @@ class Report_Query {
 
 		// Request all URLs for each report.
 		$urls = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			sprintf(
-				// phpcs:ignore WordPress.DB.PreparedSQL
-				"SELECT report_id, url FROM {$table_name} WHERE report_id IN (%s) GROUP BY report_id, url",
-				join( ',', array_map( 'intval', $non_cached_ids ) ) // phpcs:ignore WordPress.DB.PreparedSQL
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				"SELECT report_id, url FROM {$table_name} WHERE report_id IN ({$ids_sql_list}) GROUP BY report_id, url",
+				$non_cached_ids
 			),
 			ARRAY_A
 		);
 
 		// Request all user agents for each report.
 		$user_agents = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-			sprintf(
-				// phpcs:ignore WordPress.DB.PreparedSQL
-				"SELECT report_id, user_agent FROM {$table_name} WHERE report_id IN (%s) GROUP BY report_id, user_agent",
-				join( ',', array_map( 'intval', $non_cached_ids ) ) // phpcs:ignore WordPress.DB.PreparedSQL
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				"SELECT report_id, user_agent FROM {$table_name} WHERE report_id IN ({$ids_sql_list}) GROUP BY report_id, user_agent",
+				$non_cached_ids
 			),
 			ARRAY_A
 		);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prime report log data caches for report queries to significantly reduce number of SQL requests when querying multiple reports.

Adresses issue #3 

## Relevant technical choices
Originally, only the basic cache for data from the `reports` database table was primed. This now ensures that the extra cache aggregating report data taken from `report_logs` is also primed.

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
